### PR TITLE
feat(monitoring): Integrate all monitoring components

### DIFF
--- a/src/lib/monitoring/index.ts
+++ b/src/lib/monitoring/index.ts
@@ -1,31 +1,16 @@
-import { Metrics } from './metrics';
-import { Tracer } from './tracer';
+export * from './metrics';
+export * from './error-tracking';
+export * from './integration-monitor';
+export * from './database-monitor';
 
-export class Monitoring {
-  private static instance: Monitoring;
-  private metrics: Metrics;
-  private tracer: Tracer;
+// Re-export instances for convenience
+export { default as metricsCollector } from './metrics';
+export { default as errorTracker } from './error-tracking';
+export { default as databaseMonitor } from './database-monitor';
 
-  private constructor() {
-    this.metrics = new Metrics();
-    this.tracer = new Tracer();
-  }
-
-  static getInstance(): Monitoring {
-    if (!Monitoring.instance) {
-      Monitoring.instance = new Monitoring();
-    }
-    return Monitoring.instance;
-  }
-
-  recordApiCall(path: string, method: string, status: number, duration: number) {
-    this.metrics.incrementApiCalls(path, method, status);
-    this.metrics.recordApiLatency(path, method, duration);
-  }
-
-  startSpan(name: string) {
-    return this.tracer.startSpan(name);
-  }
-}
-
-export const monitoring = Monitoring.getInstance();
+// Export logger instances
+export {
+  monitoringLogger,
+  moniteLogger,
+  dbLogger,
+} from './logger';


### PR DESCRIPTION
### TL;DR
Refactored monitoring module to use individual specialized monitors instead of a singleton instance

### What changed?
- Removed the singleton `Monitoring` class in favor of separate specialized monitors
- Added exports for metrics, error tracking, integration monitoring, and database monitoring
- Introduced new logger instances for different monitoring contexts
- Simplified the module interface through direct exports

### How to test?
1. Import individual monitoring components where needed:
```typescript
import { metricsCollector, errorTracker, databaseMonitor } from './monitoring'
```
2. Verify each monitoring component works independently
3. Confirm logger instances are accessible and functioning:
```typescript
import { monitoringLogger, moniteLogger, dbLogger } from './monitoring'
```

### Why make this change?
The singleton pattern was limiting flexibility and creating unnecessary coupling between different monitoring concerns. This change improves modularity by allowing each monitoring aspect to be used independently, making the code more maintainable and easier to test. It also provides better separation of concerns between different types of monitoring.